### PR TITLE
Choose output directories for JAM and GDB

### DIFF
--- a/src/AssetConverter/main.cpp
+++ b/src/AssetConverter/main.cpp
@@ -17,36 +17,52 @@ IAssetConverter* availableConverters[]{
 
 int main(const int argc, const char** argv)
 {
-    for (auto i = 1; i < argc; i++)
+    // Make sure we got two args
+    if (argc != 3)
     {
-        fs::path targetPath(argv[i]);
-        if (!fs::exists(targetPath) || !fs::is_regular_file(targetPath))
-        {
-            std::cout << "Invalid file \"" << targetPath << "\"\n";
-            continue;
-        }
-
-        auto extension = targetPath.extension().string();
-        for (auto& c : extension)
-            c = static_cast<char>(toupper(c));
-
-        const auto availableConverter = std::find_if(std::begin(availableConverters),
-                                                     std::end(availableConverters),
-                                                     [&extension](const IAssetConverter* converter)
-                                                     {
-                                                         return converter->SupportsExtension(extension);
-                                                     });
-
-        if (availableConverter && availableConverter != std::end(availableConverters))
-        {
-            const auto directory = targetPath.parent_path().string();
-            const auto fileName = targetPath.filename().string();
-
-            (*availableConverter)->Convert(directory, fileName);
-        }
-        else
-            std::cout << "No converter for file \"" << targetPath << "\"\n";
+        std::cout << "Invalid input. \nUsage: AssetConverter INPUT.GDB output_directory\n";
+        return 1;
     }
+
+    // Get the GDB file and the output directory
+    fs::path gdbPath(argv[1]);
+    fs::path outDir(argv[2]);
+
+    // Check if GDB exists
+    if (!fs::exists(gdbPath) || !fs::is_regular_file(gdbPath))
+    {
+        std::cout << "Invalid file \"" << gdbPath << "\"\n";
+        return 1;
+    }
+
+    // Check if output directory exists
+    if (!fs::exists(outDir) || !fs::is_directory(outDir))
+    {
+        std::cout << "Invalid output directory \"" << outDir << "\"\n";
+        return 1;
+    }
+
+    auto extension = gdbPath.extension().string();
+    for (auto& c : extension)
+        c = static_cast<char>(toupper(c));
+
+    const auto availableConverter = std::find_if(std::begin(availableConverters),
+                                                 std::end(availableConverters),
+                                                 [&extension](const IAssetConverter* converter)
+                                                 {
+                                                     return converter->SupportsExtension(extension);
+                                                 });
+
+    if (availableConverter && availableConverter != std::end(availableConverters))
+    {
+        const auto directory = gdbPath.parent_path().string();
+        const auto fileName = gdbPath.filename().string();
+        const auto outDirectory = outDir.filename().string();
+
+        (*availableConverter)->Convert(directory, fileName, outDir);
+    }
+    else
+        std::cout << "No converter for file \"" << gdbPath << "\"\n";
 
     return 0;
 }

--- a/src/AssetLib/Asset/IAssetConverter.h
+++ b/src/AssetLib/Asset/IAssetConverter.h
@@ -6,7 +6,7 @@ class IAssetConverter
 {
 public:
     [[nodiscard]] virtual bool SupportsExtension(const std::string& extensionName) const = 0;
-    virtual bool Convert(const std::string& directory, const std::string& filePath) = 0;
+    virtual bool Convert(const std::string& directory, const std::string& filePath, const std::string& outDirectory) = 0;
 
 protected:
     IAssetConverter() = default;

--- a/src/AssetLib/Export/Obj/ObjExporter.cpp
+++ b/src/AssetLib/Export/Obj/ObjExporter.cpp
@@ -476,7 +476,7 @@ bool ObjExporter::SupportsExtension(const std::string& extensionName) const
     return extensionName == ".GDB";
 }
 
-bool ObjExporter::Convert(const std::string& directory, const std::string& filePath)
+bool ObjExporter::Convert(const std::string& directory, const std::string& filePath, const std::string& outDirectory)
 {
     const fs::path fsPath = fs::path(directory) / filePath;
     if (!fs::is_regular_file(fsPath))
@@ -511,7 +511,7 @@ bool ObjExporter::Convert(const std::string& directory, const std::string& fileP
     writer.ExportColors(model.m_vertex_format == gdb::VertexFormat::POSITION_UV_COLOR);
     writer.ExportNormals(model.m_vertex_format == gdb::VertexFormat::POSITION_UV_NORMAL);
 
-    if (!WriteObjFile(writer, directory, fileName) || !WriteMatFile(writer, directory, fileName))
+    if (!WriteObjFile(writer, outDirectory, fileName) || !WriteMatFile(writer, outDirectory, fileName))
         return false;
 
     return true;

--- a/src/AssetLib/Export/Obj/ObjExporter.h
+++ b/src/AssetLib/Export/Obj/ObjExporter.h
@@ -8,6 +8,6 @@ namespace obj
     {
     public:
         [[nodiscard]] bool SupportsExtension(const std::string& extensionName) const override;
-        bool Convert(const std::string& directory, const std::string& filePath) override;
+        bool Convert(const std::string& directory, const std::string& filePath, const std::string& outDirectory) override;
     };
 } // namespace obj

--- a/src/AssetLib/Export/Obj/ObjImporter.cpp
+++ b/src/AssetLib/Export/Obj/ObjImporter.cpp
@@ -47,7 +47,7 @@ bool ObjImporter::SupportsExtension(const std::string& extensionName) const
     return extensionName == ".OBJ";
 }
 
-bool ObjImporter::Convert(const std::string& directory, const std::string& filePath)
+bool ObjImporter::Convert(const std::string& directory, const std::string& filePath, const std::string& outDirectory)
 {
     const fs::path fsPath = fs::path(directory) / filePath;
     if (!fs::is_regular_file(fsPath))

--- a/src/AssetLib/Export/Obj/ObjImporter.h
+++ b/src/AssetLib/Export/Obj/ObjImporter.h
@@ -8,6 +8,6 @@ namespace obj
     {
     public:
         [[nodiscard]] bool SupportsExtension(const std::string& extensionName) const override;
-        bool Convert(const std::string& directory, const std::string& filePath) override;
+        bool Convert(const std::string& directory, const std::string& filePath, const std::string& outDirectory) override;
     };
 } // namespace obj

--- a/src/JamFileTool/JamFileDumper.cpp
+++ b/src/JamFileTool/JamFileDumper.cpp
@@ -213,7 +213,7 @@ private:
     fs::path m_dump_folder;
 };
 
-void dumping::DumpJamFile(const std::string& filePath)
+void dumping::DumpJamFile(const std::string& filePath, const std::string& outDirPath)
 {
     std::ifstream stream(filePath, std::ios::in | std::ios::binary);
     if (!stream.is_open())
@@ -222,8 +222,9 @@ void dumping::DumpJamFile(const std::string& filePath)
         return;
     }
 
-    const fs::path path(filePath);
-    const auto dumpFolder = path.parent_path() / path.filename().replace_extension();
+    const fs::path jamFilePath(filePath);
+    const fs::path path(outDirPath);
+    const auto dumpFolder = path.parent_path() / jamFilePath.filename().replace_extension();
     fs::create_directories(dumpFolder);
 
     std::cout << "Dumping JAM file \"" << filePath << "\""

--- a/src/JamFileTool/JamFileDumper.h
+++ b/src/JamFileTool/JamFileDumper.h
@@ -3,5 +3,5 @@
 
 namespace dumping
 {
-    void DumpJamFile(const std::string& filePath);
+    void DumpJamFile(const std::string& filePath, const std::string& outDirPath);
 }

--- a/src/JamFileTool/main.cpp
+++ b/src/JamFileTool/main.cpp
@@ -9,28 +9,33 @@ namespace fs = std::filesystem;
 
 int main(const int argc, const char** argv)
 {
-    for (auto i = 1; i < argc; i++)
+    // Make sure we got two args
+    if (argc != 3)
     {
-        fs::path targetPath(argv[i]);
-        if (!fs::exists(targetPath))
-        {
-            std::cout << "Invalid file or directory \"" << targetPath << "\"\n";
-            continue;
-        }
-
-        if (fs::is_directory(targetPath))
-        {
-            creating::CreateJamFile(targetPath.string());
-        }
-        else if (fs::is_regular_file(targetPath))
-        {
-            dumping::DumpJamFile(targetPath.string());
-        }
-        else
-        {
-            std::cout << "Unknown filesystem element type for \"" << targetPath << "\"\n";
-        }
+        std::cout << "Invalid input. \nUsage: JamFileTool INPUT.JAM output_directory\n";
+        return 1;
     }
+
+    // Get the JAM file and the output directory
+    fs::path jamPath(argv[1]);
+    fs::path outDir(argv[2]);
+
+    // Check if JAM exists
+    if (!fs::exists(jamPath) || !fs::is_regular_file(jamPath))
+    {
+        std::cout << "Invalid JAM file \"" << jamPath << "\"\n";
+        return 1;
+    }
+
+    // Check if output directory exists
+    if (!fs::exists(outDir) || !fs::is_directory(outDir))
+    {
+        std::cout << "Invalid output directory \"" << outDir << "\"\n";
+        return 1;
+    }
+
+    // Dump the JAM
+    dumping::DumpJamFile(jamPath.string(), outDir.string());
 
     return 0;
 }


### PR DESCRIPTION
Changed JamFileTool and AssetConverter to only take a single input file along with a directory to put the output files.  

> Updated usage:
> ```
> JamFileTool INPUT.JAM output_directory
> AssetConverter INPUT.GDB output_directory
> ```